### PR TITLE
Add a method to generate header keywords from beam object

### DIFF
--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -11,6 +11,10 @@ FWHM_TO_AREA = 2*np.pi/(8*np.log(2))
 def _to_area(major,minor):
     return (major * minor * FWHM_TO_AREA).to(u.sr)
 
+unit_format = {u.deg: '\\circ',
+               u.arcsec: "''",
+               u.arcmin: "'"}
+
 class Beam(u.Quantity):
     """
     An object to handle radio beams.
@@ -153,9 +157,10 @@ class Beam(u.Quantity):
         return "Beam: BMAJ={0} BMIN={1} BPA={2}".format(self.major.to(self.default_unit),self.minor.to(self.default_unit),self.pa.to(u.deg))
 
     def _repr_latex_(self):
-        return "Beam: BMAJ=${0}^\\circ$ BMIN=${1}^\\circ$ BPA=${2}^\\circ$".format(self.major.to(u.deg).value,
-                                                                                   self.minor.to(u.deg).value,
-                                                                                   self.pa.to(u.deg).value)
+        return "Beam: BMAJ=${0}^{{{fmt}}}$ BMIN=${1}^{{{fmt}}}$ BPA=${2}^\\circ$".format(self.major.to(self.default_unit).value,
+                                                                                         self.minor.to(self.default_unit).value,
+                                                                                         self.pa.to(u.deg).value,
+                                                                                         fmt = unit_format[self.default_unit])
 
     def __str__(self):
         return self.__repr__()

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -358,13 +358,15 @@ class Beam(u.Quantity):
     # Methods
     # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 
-    def ellipse_to_plot(self, xcen, ycen):
+    def ellipse_to_plot(self, xcen, ycen, pixscale):
         """
         Return a matplotlib ellipse
         """
         import matplotlib
-        raise NotImplementedError("Let's finish this later, k?")
-        return matplotlib.Patches.Ellipse(self.major, self.minor, self.pa)
+        return matplotlib.patches.Ellipse((xcen,ycen),
+                                          width=self.major.to(u.deg).value/pixscale,
+                                          height=self.minor.to(u.deg).value/pixscale,
+                                          angle=self.pa.to(u.deg).value)
 
     def as_kernel(self, pixscale):
         """
@@ -381,6 +383,13 @@ class Beam(u.Quantity):
         return EllipticalGaussian2DKernel(self.major.to(u.deg).value/pixscale,
                                           self.minor.to(u.deg).value/pixscale,
                                           self.pa.to(u.radian).value)
+
+    def to_header_keywords(self):
+        return {'BMAJ': self.major.to(u.deg).value,
+                'BMIN': self.major.to(u.deg).value,
+                'BPA':  self.pa.to(u.deg).value,
+               }
+
 
 def wcs_to_platescale(wcs):
     cdelt = np.matrix(wcs.get_cdelt())


### PR DESCRIPTION
This is necessary for proper treatment of the beam in `spectral_cube`; see https://github.com/radio-astro-tools/spectral-cube/issues/183 and https://github.com/radio-astro-tools/spectral-cube/issues/184