### PR TITLE
Update kernel with astropy 1.0.3 changes

### DIFF
--- a/radio_beam/__init__.py
+++ b/radio_beam/__init__.py
@@ -1,2 +1,2 @@
 from version import __version__
-from beam import Beam
+from beam import Beam, EllipticalGaussian2DKernel

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -496,4 +496,4 @@ class EllipticalGaussian2DKernel(Kernel2D):
         self._default_size = _round_up_to_odd_integer(support_scaling *
                                                       np.max([width,height]))
         super(EllipticalGaussian2DKernel, self).__init__(**kwargs)
-        self._truncation = np.abs(1. - 1 / self._normalization)
+        self._truncation = np.abs(1. - 1 / self._array.sum())


### PR DESCRIPTION
[Kernel normalization](https://github.com/astropy/astropy/pull/3747) was changed in astropy 1.0.3. ```EllipticalGaussian2DKernel``` needed to be updated accordingly.