### PR TITLE
Beam as structure element

### DIFF
--- a/radio_beam/__init__.py
+++ b/radio_beam/__init__.py
@@ -1,2 +1,2 @@
 from version import __version__
-from beam import Beam, EllipticalGaussian2DKernel
+from beam import Beam, EllipticalGaussian2DKernel, EllipticalDisk2D, EllipticalTophat2DKernel

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -435,6 +435,16 @@ class Beam(u.Quantity):
                                           self.minor.to(u.deg).value/pixscale,
                                           self.pa.to(u.radian).value)
 
+    def as_struct_element(self, pixscale):
+
+        # Same as above...
+        warnings.warn("as_struct_element is not aware of any misaligment "
+                      " between pixel and world coordinates")
+
+        return EllipticalTophat2DKernel(self.major.to(u.deg).value/pixscale,
+                                        self.minor.to(u.deg).value/pixscale,
+                                        self.pa.to(u.radian).value)
+
     def to_header_keywords(self):
         return {'BMAJ': self.major.to(u.deg).value,
                 'BMIN': self.minor.to(u.deg).value,

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -462,7 +462,7 @@ class Beam(u.Quantity):
         maj_eff = self.major.to(u.deg) / (pixscale*gauss_to_tophat)
         min_eff = self.minor.to(u.deg) / (pixscale*gauss_to_tophat)
 
-        return EllipticalTophat2DKernel(maj_eff, min_eff,
+        return EllipticalTophat2DKernel(maj_eff.value, min_eff.value,
                                         self.pa.to(u.radian).value)
 
     def to_header_keywords(self):

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -451,6 +451,12 @@ class Beam(u.Quantity):
         warnings.warn("as_struct_element is not aware of any misaligment "
                       " between pixel and world coordinates")
 
+        # Based on Gaussian to Tophat area conversion
+        # A_gaussian = 2 * pi * sigma^2 / (sqrt(8*log(2))^2
+        # A_tophat = pi * r^2
+        # pi r^2 = 2 * pi * sigma^2 / (sqrt(8*log(2))^2
+        # r = sqrt(2)/sqrt(8*log(2)) * sigma
+
         gauss_to_tophat = 2*np.sqrt(np.log(2))
 
         maj_eff = self.major.to(u.deg) / (pixscale*gauss_to_tophat)

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -581,13 +581,12 @@ class EllipticalDisk2D(Fittable2DModel):
 
     Notes
     -----
-    ** NOT UPDATED **
     Model formula:
         .. math::
-            f(r) = \\left \\{
+            f(a, b) = \\left \\{
                      \\begin{array}{ll}
-                       A & : r \\leq R_0 \\\\
-                       0 & : r > R_0
+                       A & : \\freq{(x\\cos{\\theta}+y\\sin{\\theta})^2}{a^2} + \\freq{(x\\sin{\\theta}-y\\cos{\\theta})^2}{b^2} \\leq 1 \\\\
+                       0 & : \\freq{(x\\cos{\\theta}+y\\sin{\\theta})^2}{a^2} + \\freq{(x\\sin{\\theta}-y\\cos{\\theta})^2}{b^2} > 1
                      \\end{array}
                    \\right.
     """

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -419,6 +419,8 @@ class Beam(u.Quantity):
 
     def as_kernel(self, pixscale):
         """
+        Returns an elliptical Gaussian kernel of the beam.
+
         Parameters
         ----------
         pixscale : float
@@ -436,6 +438,14 @@ class Beam(u.Quantity):
                                           self.pa.to(u.radian).value)
 
     def as_tophat_kernel(self, pixscale):
+        '''
+        Returns an elliptical Top Hat kernel of the beam.
+
+        Parameters
+        ----------
+        pixscale : float
+            deg -> pixels
+        '''
 
         # Same as above...
         warnings.warn("as_struct_element is not aware of any misaligment "

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -7,6 +7,12 @@ from astropy.extern import six
 import numpy as np
 import warnings
 
+# Imports for the custom kernels
+from astropy.modeling import models, Fittable2DModel, Parameter
+from astropy.convolution import Kernel2D
+from astropy.convolution.kernels import _round_up_to_odd_integer
+from astropy.modeling.parameters import InputParameterError
+
 # Conversion between a twod Gaussian FWHM**2 and effective area
 FWHM_TO_AREA = 2*np.pi/(8*np.log(2))
 
@@ -444,9 +450,6 @@ def wcs_to_platescale(wcs):
     pixscale = np.abs(scale[0])
     return pixscale
 
-from astropy.modeling import models
-from astropy.convolution import Kernel2D
-from astropy.convolution.kernels import _round_up_to_odd_integer
 
 class EllipticalGaussian2DKernel(Kernel2D):
     """
@@ -522,3 +525,84 @@ class EllipticalGaussian2DKernel(Kernel2D):
                                                       np.max([width,height]))
         super(EllipticalGaussian2DKernel, self).__init__(**kwargs)
         self._truncation = np.abs(1. - 1 / self._array.sum())
+
+
+class EllipticalDisk2D(Fittable2DModel):
+    """
+    Two dimensional elliptical Disk model.
+    Parameters
+    ----------
+    amplitude : float
+        Value of the disk function
+    x_0 : float
+        x position center of the disk
+    y_0 : float
+        y position center of the disk
+    a : float
+        Major axis of the disk
+    b : float
+        Minor axis of the disk
+    theta : float
+        Orientation of the major axis with respect to the x axis.
+
+    See Also
+    --------
+    Box2D, TrapezoidDisk2D, Disk2D
+
+    Notes
+    -----
+    ** NOT UPDATED **
+    Model formula:
+        .. math::
+            f(r) = \\left \\{
+                     \\begin{array}{ll}
+                       A & : r \\leq R_0 \\\\
+                       0 & : r > R_0
+                     \\end{array}
+                   \\right.
+    """
+
+    amplitude = Parameter(default=1)
+    x_0 = Parameter(default=0)
+    y_0 = Parameter(default=0)
+    a = Parameter(default=1)
+    b = Parameter(default=1)
+    theta = Parameter(default=0)
+
+    def __init__(self, amplitude=amplitude.default, x_0=x_0.default,
+                 y_0=y_0.default, a=a.default, b=b.default,
+                 theta=theta.default, **kwargs):
+
+        if a < b:
+            raise InputParameterError("Major axis (a) must be greater than "
+                                      "minor axis (b).")
+
+        super(EllipticalDisk2D, self).__init__(
+            amplitude=amplitude, x_0=x_0, y_0=y_0, a=a, b=b, theta=theta,
+            **kwargs)
+
+    @staticmethod
+    def evaluate(x, y, amplitude, x_0,
+                 y_0, a, b, theta):
+        """Two dimensional elliptical Disk model function"""
+
+        majr = (((x - x_0)*np.cos(theta) + (y - y_0)*np.sin(theta)) ** 2) /\
+            a ** 2
+        minr = (((x - x_0)*np.sin(theta) - (y - y_0)*np.cos(theta)) ** 2) /\
+            b ** 2
+        return np.select([majr + minr <= 1.], [amplitude])
+
+
+class EllipticalTophat2DKernel(Kernel2D):
+    """docstring for EllipticalTophat2DKernel"""
+
+    _is_bool = True
+
+    def __init__(self, width, height, position_angle, support_scaling=8, **kwargs):
+
+        self._model = EllipticalDisk2D(1. / (np.pi * width * height), 0, 0,
+                                       width, height, position_angle)
+        self._default_size = _round_up_to_odd_integer(support_scaling *
+                                                      np.max([width, height]))
+        super(EllipticalTophat2DKernel, self).__init__(**kwargs)
+        self._truncation = 0

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -435,14 +435,18 @@ class Beam(u.Quantity):
                                           self.minor.to(u.deg).value/pixscale,
                                           self.pa.to(u.radian).value)
 
-    def as_struct_element(self, pixscale):
+    def as_tophat_kernel(self, pixscale):
 
         # Same as above...
         warnings.warn("as_struct_element is not aware of any misaligment "
                       " between pixel and world coordinates")
 
-        return EllipticalTophat2DKernel(self.major.to(u.deg).value/pixscale,
-                                        self.minor.to(u.deg).value/pixscale,
+        gauss_to_tophat = 2*np.sqrt(np.log(2))
+
+        maj_eff = self.major.to(u.deg) / (pixscale*gauss_to_tophat)
+        min_eff = self.minor.to(u.deg) / (pixscale*gauss_to_tophat)
+
+        return EllipticalTophat2DKernel(maj_eff, min_eff,
                                         self.pa.to(u.radian).value)
 
     def to_header_keywords(self):


### PR DESCRIPTION
Implements an ```EllipticalTophat2DKernel```, allowing for the beam to be converted into a structure element for morphological operations. This required implementing an ```EllipticalDisk2D``` model as well.