### PR TITLE
Kernel strip stddev units

### DIFF
--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -460,8 +460,8 @@ class Beam(u.Quantity):
         stddev_maj = self.major.to(u.deg)/(pixscale * SIGMA_TO_FWHM)
         stddev_min = self.minor.to(u.deg)/(pixscale * SIGMA_TO_FWHM)
 
-        return EllipticalGaussian2DKernel(stddev_maj,
-                                          stddev_min,
+        return EllipticalGaussian2DKernel(stddev_maj.value,
+                                          stddev_min.value,
                                           self.pa.to(u.radian).value,
                                           **kwargs)
 
@@ -583,8 +583,8 @@ class EllipticalGaussian2DKernel(Kernel2D):
     _separable = True
     _is_bool = False
 
-    def __init__(self, stddev_maj, stddev_min, position_angle, support_scaling=8,
-                 **kwargs):
+    def __init__(self, stddev_maj, stddev_min, position_angle,
+                 support_scaling=8, **kwargs):
         self._model = Gaussian2D(1. / (2 * np.pi * stddev_maj * stddev_min), 0,
                                  0, x_stddev=stddev_maj, y_stddev=stddev_min,
                                  theta=position_angle)

--- a/radio_beam/tests/test_kernels.py
+++ b/radio_beam/tests/test_kernels.py
@@ -2,11 +2,17 @@
 from .. import beam as radio_beam
 import numpy.testing as npt
 import numpy as np
-
+import pytest
+from pkg_resources import parse_version
+from astropy.version import version
 
 SIGMA_TO_FWHM = radio_beam.SIGMA_TO_FWHM
 
+min_astropy_version = parse_version("1.1")
 
+
+@pytest.mark.skipif(parse_version(version) < min_astropy_version,
+                    reason="Must have astropy version >1.1")
 def test_gauss_kernel():
 
     fake_beam = radio_beam.Beam(10)
@@ -22,6 +28,8 @@ def test_gauss_kernel():
     npt.assert_allclose(kernel.array, direct_kernel.array)
 
 
+@pytest.mark.skipif(parse_version(version) < min_astropy_version,
+                    reason="Must have astropy version >1.1")
 def test_tophat_kernel():
 
     fake_beam = radio_beam.Beam(10)

--- a/radio_beam/tests/test_kernels.py
+++ b/radio_beam/tests/test_kernels.py
@@ -1,0 +1,37 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+from .. import beam as radio_beam
+import numpy.testing as npt
+import numpy as np
+
+
+SIGMA_TO_FWHM = radio_beam.SIGMA_TO_FWHM
+
+
+def test_gauss_kernel():
+
+    fake_beam = radio_beam.Beam(10)
+
+    # Let pixscale be 0.1 pix/deg
+    kernel = fake_beam.as_kernel(0.1)
+
+    direct_kernel = \
+        radio_beam.EllipticalGaussian2DKernel(100. / SIGMA_TO_FWHM,
+                                              100. / SIGMA_TO_FWHM,
+                                              0.0)
+
+    npt.assert_allclose(kernel.array, direct_kernel.array)
+
+
+def test_tophat_kernel():
+
+    fake_beam = radio_beam.Beam(10)
+
+    # Let pixscale be 0.1 pix/deg
+    kernel = fake_beam.as_tophat_kernel(0.1)
+
+    direct_kernel = \
+        radio_beam.EllipticalTophat2DKernel(100. / (SIGMA_TO_FWHM/np.sqrt(2)),
+                                            100. / (SIGMA_TO_FWHM/np.sqrt(2)),
+                                            0.0)
+
+    npt.assert_allclose(kernel.array, direct_kernel.array)


### PR DESCRIPTION
Can't pass units into `ellipse_extent`. Added a couple kernel creation tests.