### PR TITLE
Pass pixscale to ellipse_to_plot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.12
+        - NUMPY_VERSION=1.11
         # NOTE: This should be reverted to 1.2 once 1.2 is released (circmean
         # is part of 1.2 and is required)
         - ASTROPY_VERSION=development
@@ -61,16 +61,19 @@ matrix:
 
         # Test older numpy versions >=1.9
         - python: 2.7
-          env: NUMPY_VERSION=1.9
-        - python: 2.7
           env: NUMPY_VERSION=1.10
         - python: 2.7
-          env: NUMPY_VERSION=1.11
-        # Deprecate older numpy versions as spectral-cube has.
-        # - python: 2.7
-        #   env: NUMPY_VERSION=1.8
-        # - python: 2.7
-        #   env: NUMPY_VERSION=1.7
+          env: NUMPY_VERSION=1.9
+        - python: 2.7
+          env: NUMPY_VERSION=1.8
+        - python: 2.7
+          env: NUMPY_VERSION=1.7
+
+        # Test newest numpy version, which won't work with python 3.4
+        - python: 2.7
+          env: NUMPY_VERSION=1.12
+        - python: 3.5
+          env: NUMPY_VERSION=1.12
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,6 @@ install:
     # other dependencies.
 
 script:
-   - if [[ $SETUP_CMD != egg_info ]]; then cd radio_beam/tests/data; make; cd ../../../; fi
    - python setup.py $SETUP_CMD
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.9
+        - NUMPY_VERSION=1.12
         # NOTE: This should be reverted to 1.2 once 1.2 is released (circmean
         # is part of 1.2 and is required)
         - ASTROPY_VERSION=development
@@ -59,11 +59,18 @@ matrix:
         - python: 3.4
           env: ASTROPY_VERSION=development
 
-        # Try older numpy versions
+        # Test older numpy versions >=1.9
         - python: 2.7
-          env: NUMPY_VERSION=1.8
+          env: NUMPY_VERSION=1.9
         - python: 2.7
-          env: NUMPY_VERSION=1.7
+          env: NUMPY_VERSION=1.10
+        - python: 2.7
+          env: NUMPY_VERSION=1.11
+        # Deprecate older numpy versions as spectral-cube has.
+        # - python: 2.7
+        #   env: NUMPY_VERSION=1.8
+        # - python: 2.7
+        #   env: NUMPY_VERSION=1.7
 
 before_install:
 
@@ -92,7 +99,7 @@ install:
     # As described above, using ci-helpers, you should be able to set up an
     # environment with dependencies installed using conda and pip, but in some
     # cases this may not provide enough flexibility in how to install a
-    # specific dependency (and it will not be able to install non-Python 
+    # specific dependency (and it will not be able to install non-Python
     # dependencies). Therefore, you can also include commands below (as
     # well as at the start of the install section or in the before_install
     # section if they are needed before setting up conda) to install any

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,12 +33,12 @@ Convolve with another beam::
 
     >>> my_asymmetric_beam = Beam(0.75*u.arcsec, 0.25*u.arcsec, 0*u.deg)
     >>> my_other_asymmetric_beam = Beam(0.75*u.arcsec, 0.25*u.arcsec, 90*u.deg)
-    >>> my_asymmetric_beam.convolve(my_other_asymmetric_beam)
+    >>> my_asymmetric_beam.convolve(my_other_asymmetric_beam)  # doctest: +SKIP
     Beam: BMAJ=0.790569415042 arcsec BMIN=0.790569415042 arcsec BPA=45.0 deg
 
 Deconvolve another beam::
 
     >>> my_big_beam = Beam(1.0*u.arcsec, 1.0*u.arcsec, 0*u.deg)
     >>> my_little_beam = Beam(0.5*u.arcsec, 0.5*u.arcsec, 0*u.deg)
-    >>> my_big_beam.deconvolve(my_little_beam)
+    >>> my_big_beam.deconvolve(my_little_beam)  # doctest: +SKIP
     Beam: BMAJ=0.866025403784 arcsec BMIN=0.866025403784 arcsec BPA=0.0 deg

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,9 +12,9 @@ Read a beam from a fits header::
 
     >>> from radio_beam import Beam
     >>> from astropy.io import fits
-    >>> header = fits.getheader('file.fits')
-    >>> my_beam = Beam.from_fits_header(header)
-    >>> print(my_beam)
+    >>> header = fits.getheader('file.fits')  # doctest: +SKIP
+    >>> my_beam = Beam.from_fits_header(header)  # doctest: +SKIP
+    >>> print(my_beam)  # doctest: +SKIP
     Beam: BMAJ=0.038652855902928 arcsec BMIN=0.032841067761183604 arcsec BPA=32.29655838013 deg
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,11 +34,11 @@ Convolve with another beam::
     >>> my_asymmetric_beam = Beam(0.75*u.arcsec, 0.25*u.arcsec, 0*u.deg)
     >>> my_other_asymmetric_beam = Beam(0.75*u.arcsec, 0.25*u.arcsec, 90*u.deg)
     >>> my_asymmetric_beam.convolve(my_other_asymmetric_beam)
-    Beam: BMAJ=0.7905694150420949 arcsec BMIN=0.7905694150420949 arcsec BPA=45.0 deg
+    Beam: BMAJ=0.790569415042 arcsec BMIN=0.790569415042 arcsec BPA=45.0 deg
 
 Deconvolve another beam::
 
     >>> my_big_beam = Beam(1.0*u.arcsec, 1.0*u.arcsec, 0*u.deg)
     >>> my_little_beam = Beam(0.5*u.arcsec, 0.5*u.arcsec, 0*u.deg)
     >>> my_big_beam.deconvolve(my_little_beam)
-    Beam: BMAJ=0.8660254037844386 arcsec BMIN=0.8660254037844386 arcsec BPA=0.0 deg
+    Beam: BMAJ=0.866025403784 arcsec BMIN=0.866025403784 arcsec BPA=0.0 deg

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -526,18 +526,24 @@ class Beam(u.Quantity):
 
         return value.to(u.K, self.jtok_equiv(freq))
 
-    def ellipse_to_plot(self, xcen, ycen, units=u.deg, wcs=None):
+    def ellipse_to_plot(self, xcen, ycen, pixscale):
         """
         Return a matplotlib ellipse for plotting
 
-        .. todo::
-            Implement this!
+        Parameters
+        ----------
+        xcen : int
+            Center pixel in the x-direction.
+        ycen : int
+            Center pixel in the y-direction.
+        pixscale : `~astropy.units.Quantity`
+            Conversion from degrees to pixels.
         """
-        import matplotlib
-        return matplotlib.patches.Ellipse((xcen,ycen),
-                                          width=self.major.to(u.deg).value/pixscale,
-                                          height=self.minor.to(u.deg).value/pixscale,
-                                          angle=self.pa.to(u.deg).value)
+        from matplotlib.patches import Ellipse
+        return Ellipse((xcen, ycen),
+                       width=self.major.to(u.deg).value / pixscale,
+                       height=self.minor.to(u.deg).value / pixscale,
+                       angle=self.pa.to(u.deg).value)
 
     def as_kernel(self, pixscale, **kwargs):
         """

--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -538,6 +538,11 @@ class Beam(u.Quantity):
             Center pixel in the y-direction.
         pixscale : `~astropy.units.Quantity`
             Conversion from degrees to pixels.
+
+        Returns
+        -------
+        ~matplotlib.patches.Ellipse
+            Ellipse patch object centered on the given pixel coordinates.
         """
         from matplotlib.patches import Ellipse
         return Ellipse((xcen, ycen),

--- a/radio_beam/tests/data/Makefile
+++ b/radio_beam/tests/data/Makefile
@@ -1,8 +1,0 @@
-all: advs.fits
-
-%.fits:
-	python -c "import runpy;\
-	           from spectral_cube.tests.data import make_test_cubes;\
-			   runpy.run_path(make_test_cubes.__file__,\
-			                  run_name='__main__')"
-


### PR DESCRIPTION
`ellipse_to_plot` was never finished. Since we pass `pixscale` in everywhere else, it should be passed instead of `wcs`.

Other changes:
* skipping doc tests in `index.rst`
* Added testing for newer numpy versions
* Removed the make file in `tests/data/` which was accidently copied over from the `spectral-cube`