### PR TITLE
Use a custom exception to indicate no beam is present

### DIFF
--- a/radio_beam/beam.py
+++ b/radio_beam/beam.py
@@ -16,6 +16,9 @@ from astropy.convolution.kernels import _round_up_to_odd_integer
 FWHM_TO_AREA = 2*np.pi/(8*np.log(2))
 SIGMA_TO_FWHM = np.sqrt(8*np.log(2))
 
+class NoBeamException(Exception):
+    pass
+
 def _to_area(major,minor):
     return (major * minor * FWHM_TO_AREA).to(u.sr)
 
@@ -158,7 +161,7 @@ class Beam(u.Quantity):
             if hist_beam is not None:
                 return hist_beam
             else:
-                raise TypeError("No BMAJ found and does not appear to be a CASA/AIPS header.")
+                raise NoBeamException("No BMAJ found and does not appear to be a CASA/AIPS header.")
 
         # Fill out the minor axis and position angle if they are
         # present. Else they will default .


### PR DESCRIPTION
This allows us to then deal with it correctly in spectral-cube